### PR TITLE
check comments. refactor, update func, more

### DIFF
--- a/src/main/java/com/geoshare/backend/BackendApplication.java
+++ b/src/main/java/com/geoshare/backend/BackendApplication.java
@@ -3,12 +3,14 @@ package com.geoshare.backend;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.geoshare.backend.entity.GeoshareUser;
 import com.geoshare.backend.repository.GeoshareUserRepository;
 
+@EnableCaching
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/com/geoshare/backend/controller/CountryController.java
+++ b/src/main/java/com/geoshare/backend/controller/CountryController.java
@@ -21,12 +21,6 @@ public class CountryController {
 		this.countryService = countryService;
 	}
 	
-	@GetMapping("/find")
-	public Country getCountry(
-			@RequestParam(value = "countryID", required = true)Long countryID) {
-		return countryService.findByID(countryID);
-	}
-	
 	@GetMapping("/findall")
 	public List<Country> getAllCountries() {
 		return countryService.findAll();

--- a/src/main/java/com/geoshare/backend/controller/LocationController.java
+++ b/src/main/java/com/geoshare/backend/controller/LocationController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -98,6 +99,15 @@ public class LocationController {
 		return new ResponseEntity<>("Delete request ran with no errors.", HttpStatus.OK);
 	
 		
+	}
+	
+	@PutMapping("/update")
+	public ResponseEntity<String> updateLocation(
+			@Valid @RequestBody(required = true) LocationDTO locationDTO,
+			Authentication auth) {
+		
+		locationService.updateLocation(locationDTO, auth);
+		return new ResponseEntity<>("Update request ran with no errors.", HttpStatus.OK);
 	}
 	
 }

--- a/src/main/java/com/geoshare/backend/controller/MetaController.java
+++ b/src/main/java/com/geoshare/backend/controller/MetaController.java
@@ -15,15 +15,12 @@ import com.geoshare.backend.service.MetaService;
 @RequestMapping("/api/metas")
 public class MetaController {
 
-	@Autowired
 	private MetaService metaService;
 	
-	@GetMapping("/find")
-	public Meta getMeta(
-			@RequestParam(value="metaid", required = true) Long metaID) {
-		return metaService.findByID(metaID);
+	public MetaController(MetaService metaService) {
+		this.metaService = metaService;
 	}
-	
+
 	@GetMapping("/findall")
 	public List<Meta> getAllMetas() {
 		return metaService.findAll();

--- a/src/main/java/com/geoshare/backend/entity/Meta.java
+++ b/src/main/java/com/geoshare/backend/entity/Meta.java
@@ -24,7 +24,7 @@ public class Meta {
 	@Column(name="name")
 	private String name;
 	
-	public Long getId() {
+	public Long getID() {
 		return id;
 	}
 

--- a/src/main/java/com/geoshare/backend/repository/CountryRepository.java
+++ b/src/main/java/com/geoshare/backend/repository/CountryRepository.java
@@ -14,21 +14,26 @@ import jakarta.persistence.EntityNotFoundException;
 @Repository
 public interface CountryRepository extends CrudRepository<Country, Long> {
 	
-	@Query("SELECT C FROM Country C WHERE C.id = :id")
-	Optional<Country> findByID(Long id);
+/**Removed all this fun JPQL stuff and replaced it with service layer
+ * 	functionality which resulted in fewer lines of code, and much, much better performance.
+ */
 	
-	default Country findByIDOrThrow(long id) {
-		return findByID(id).orElseThrow(() -> 
-				new EntityNotFoundException("Country not found in database"));
-	}
-	
-	@Query("SELECT C FROM Country C WHERE C.name = :name") 
-	Optional<Country> findByName(String name);
-	
-	default Country findByNameOrThrow(String name) {
-		return findByName(name).orElseThrow( () -> 
-			new EntityNotFoundException("Country not found in database"));
-	}
+//	
+//	@Query("SELECT C FROM Country C WHERE C.id = :id")
+//	Optional<Country> findByID(Long id);
+//	
+//	default Country findByIDOrThrow(long id) {
+//		return findByID(id).orElseThrow(() -> 
+//				new EntityNotFoundException("Country not found in database"));
+//	}
+//	
+//	@Query("SELECT C FROM Country C WHERE C.name = :name") 
+//	Optional<Country> findByName(String name);
+//	
+//	default Country findByNameOrThrow(String name) {
+//		return findByName(name).orElseThrow( () -> 
+//			new EntityNotFoundException("Country not found in database"));
+//	}
 	
 	List<Country> findAll();
 	

--- a/src/main/java/com/geoshare/backend/repository/MetaRepository.java
+++ b/src/main/java/com/geoshare/backend/repository/MetaRepository.java
@@ -14,21 +14,25 @@ import jakarta.persistence.EntityNotFoundException;
 @Repository
 public interface MetaRepository extends CrudRepository<Meta, Long> {
 	
-	@Query("SELECT M FROM Meta M WHERE M.id = :id")
-	Optional<Meta> findByID(Long id);
+/**Removed all this fun JPQL stuff and replaced it with service layer
+ * 	functionality which resulted in fewer lines of code, and much, much better performance.
+ */
 	
-	default Meta findByIDOrThrow(Long id) {
-		return findByID(id).orElseThrow(() ->
-			new EntityNotFoundException("Meta not found in database"));
-	}
-	
-	@Query("SELECT M FROM Meta M WHERE M.name = :name")
-	Optional<Meta> findByName(String name);
-	
-	default Meta findByNameOrThrow(String name) {
-		return findByName(name).orElseThrow(() -> 
-			new EntityNotFoundException("Meta not found in database"));
-	}
+//	@Query("SELECT M FROM Meta M WHERE M.id = :id")
+//	Optional<Meta> findByID(Long id);
+//	
+//	default Meta findByIDOrThrow(Long id) {
+//		return findByID(id).orElseThrow(() ->
+//			new EntityNotFoundException("Meta not found in database"));
+//	}
+//	
+//	@Query("SELECT M FROM Meta M WHERE M.name = :name")
+//	Optional<Meta> findByName(String name);
+//	
+//	default Meta findByNameOrThrow(String name) {
+//		return findByName(name).orElseThrow(() -> 
+//			new EntityNotFoundException("Meta not found in database"));
+//	}
 	
 	List<Meta> findAll();
 	

--- a/src/main/java/com/geoshare/backend/service/CountryService.java
+++ b/src/main/java/com/geoshare/backend/service/CountryService.java
@@ -1,31 +1,66 @@
 package com.geoshare.backend.service;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.geoshare.backend.entity.Country;
 import com.geoshare.backend.repository.CountryRepository;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Slf4j
 public class CountryService {
 	
-	@Autowired
 	private CountryRepository countryRepository;
 	
-	public Country findByID(Long id) {
-		Country country = countryRepository.findByIDOrThrow(id);
+	public CountryService(CountryRepository countryRepository) {
+		this.countryRepository = countryRepository;
+	}
+	
+	//Return a country by ID
+	public Country findCountry(Long id) {
+		Country country = mapCountriesByID().get(id);
+		
+		if (country == null) {
+			throw new EntityNotFoundException("Unable to find country by ID: " + id);
+		}
 		
 		return country;
 	}
 	
+	//Return a country by Name
+	public Country findCountry(String name) {
+		Country country = mapCountriesByName().get(name);
+		
+		if (country == null) {
+			throw new EntityNotFoundException("Unable to find country by name: " + name);
+		}
+		
+		return country;
+	}
+	
+	@Cacheable("countries_list")
 	public List<Country> findAll() {
 		return countryRepository.findAll();
 	}
 	
+	@Cacheable("countries_map_id")
+	public Map<Long, Country> mapCountriesByID() {
+		return countryRepository.findAll()
+				.stream()
+				.collect(Collectors.toMap(c -> c.getID(), c -> c));
+	}
+	
+	@Cacheable("countries_map_name")
+    public Map<String, Country> mapCountriesByName() {
+        return countryRepository.findAll()
+        		.stream()
+        		.collect(Collectors.toMap(c -> c.getName(), c -> c));
+    }
 }

--- a/src/main/java/com/geoshare/backend/service/MetaService.java
+++ b/src/main/java/com/geoshare/backend/service/MetaService.java
@@ -1,24 +1,65 @@
 package com.geoshare.backend.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.geoshare.backend.entity.Meta;
 import com.geoshare.backend.repository.MetaRepository;
 
+import jakarta.persistence.EntityNotFoundException;
+
 @Service
 public class MetaService {
 
-	@Autowired
 	private MetaRepository metaRepository;
 	
-	public Meta findByID(Long id) {
-		return metaRepository.findByIDOrThrow(id);
+	public MetaService(MetaRepository metaRepository) {
+		this.metaRepository = metaRepository;
+	}
+
+	//Return a meta by ID
+	public Meta findMeta(Long id) {
+		Meta meta = mapMetasByID().get(id);
+		
+		if (meta == null) {
+			throw new EntityNotFoundException("Unable to find meta by ID: " + id);
+		}
+		
+		return meta;
 	}
 	
+	//Return a meta by Name
+	public Meta findMeta(String name) {
+		Meta meta = mapMetasByName().get(name);
+		
+		if (meta == null) {
+			throw new EntityNotFoundException("Unable to find meta by name: " + name);
+		}
+		
+		return meta;
+	}
+	
+	@Cacheable("metas_list")
 	public List<Meta> findAll() {
 		return metaRepository.findAll();
 	}
+	
+	@Cacheable("metas_map_id")
+    public Map<Long, Meta> mapMetasByID() {
+        return metaRepository.findAll()
+        		.stream()
+        		.collect(Collectors.toMap(m -> m.getID(), m -> m));
+    }
+	
+	@Cacheable("metas_map_name")
+    public Map<String, Meta> mapMetasByName() {
+        return metaRepository.findAll()
+        		.stream()
+        		.collect(Collectors.toMap(m -> m.getName(), m -> m));
+    }
 }


### PR DESCRIPTION
Ran into the issue of having to look up Countries or Metas by their name every time I want to update a Location which really sucks.
Caused by my frontend only passing country names or meta names, but Location object wants a full Country or Meta object for JPA. 
Causing so many DB hits. So I researched Spring cache functionality and added caching to CountryService and MetaService.
Also changed these services to store Countries and Metas as HashMaps with keys of both name and ID for quick lookup, so	
	if we need to update a Location to have a new Country, we can just get the new Country object by name from the DTO,
	instead of old way of DB lookup, or newer-old way of cached ArrayList and search. Now O(1) lookup always. Cost is now just single creation and storage in app memory of four Maps.
Had to be mindful that Map.get() can be null, so after this I took steps to ensure that null checking is done at the lowest level
	so later on other classes can use these services and not have to null check over and over.
Cut out a whole bunch of JPQL as a result.